### PR TITLE
Fixed npe budget scan

### DIFF
--- a/configs/experiments/npe_budget_scan.yaml
+++ b/configs/experiments/npe_budget_scan.yaml
@@ -5,7 +5,7 @@
 budgets: [100, 200, 500, 1000, 2000, 5000, 10000, 20200]
 
 # Summary pre-computation
-n_noise_realizations: 16
+n_noise_realizations: 1
 
 # NPE training
 npe_epochs: 500

--- a/scripts/run_npe_budget_scan.py
+++ b/scripts/run_npe_budget_scan.py
@@ -29,7 +29,7 @@ from glob import glob
 @dataclass
 class NPEConfig:
     budgets: List[int] = field(default_factory=lambda: [100, 200, 500, 1000, 2000, 5000, 10000, 20200])
-    n_noise_realizations: int = 16
+    n_noise_realizations: int = 1
     npe_epochs: int = 500
     npe_lr: float = 1e-3
     npe_batch_size: int = 512
@@ -201,8 +201,8 @@ def _train_budget_core(budget: int, checkpoints_path, npe_results_path, summarie
                 kappa_reshaped = reshape_field_numpy(kappa_i[np.newaxis])[0]  # (1834, 88)
 
                 for _ in range(cfg.n_noise_realizations):
-                    noise = np.random.randn(*kappa_reshaped.shape).astype(np.float32) * NOISE_STD
-                    noisy = (kappa_reshaped + noise) * mask
+                    # noise = np.random.randn(*kappa_reshaped.shape).astype(np.float32) * NOISE_STD
+                    noisy = kappa_reshaped * mask # kappa maps from the holdout dataset are already noisy
                     x = torch.from_numpy(noisy).unsqueeze(0).to(device)  # (1, 1834, 88)
                     s = compressor.compress(x)  # (1, 8)
                     all_summaries.append(s.cpu())
@@ -343,7 +343,8 @@ def _train_budget_core(budget: int, checkpoints_path, npe_results_path, summarie
 
             # Single noisy observation
             noise = np.random.randn(*kappa_reshaped.shape).astype(np.float32) * NOISE_STD
-            noisy = (kappa_reshaped + noise) * mask
+            # noisy = (kappa_reshaped + noise) * mask
+            noisy = kappa_reshaped * mask # the holdout dataset is already noisy. 
             x = torch.from_numpy(noisy).unsqueeze(0).to(device)
             s = compressor.compress(x)  # (1, 8)
 
@@ -386,7 +387,8 @@ def _train_budget_core(budget: int, checkpoints_path, npe_results_path, summarie
     }
     (results_dir / "results.json").write_text(json.dumps(results, indent=2))
 
-    vol.commit()
+    if vol is not None:
+        vol.commit()
     print(f"Results saved to {results_dir}")
     print(f"Budget {budget}: DONE (FoM = {fom_mean:.2f} ± {fom_std:.2f})")
     return results


### PR DESCRIPTION
- Removed noise added on kappa maps on the holdout dataset;
- Changed configs/experiments/npe_budget_scan.yaml to have `n_noise_realizations=1`. 

I sent a test run to train the NPE and the script seems to work fine so far. 