### PR TITLE
Add TARP + MIRA posterior calibration to NPE budget scan

### DIFF
--- a/configs/experiments/npe_budget_scan.yaml
+++ b/configs/experiments/npe_budget_scan.yaml
@@ -16,3 +16,7 @@ npe_seeds: 5
 
 # FoM evaluation
 n_posterior_samples: 10000
+
+# Calibration validation (TARP + MIRA) — requires `pip install tarp mira_score`
+n_val_maps: 500
+n_val_posterior_samples: 1000

--- a/cosmoford/models_nopatch.py
+++ b/cosmoford/models_nopatch.py
@@ -5,6 +5,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from cosmoford import THETA_MEAN, THETA_STD, SURVEY_MASK, NOISE_STD
+from cosmoford.dataset import reshape_field_numpy
 from cosmoford.summaries import power_spectrum_batch
 from torchvision.models.efficientnet import efficientnet_b0, efficientnet_b2, efficientnet_v2_s, efficientnet_v2_m
 from torchvision.models.resnet import resnet18, ResNet18_Weights
@@ -42,7 +43,8 @@ class RegressionModelNoPatch(L.LightningModule):
                total_steps: int = 0,
                n_val_noise: int = 1,
                use_peft: bool = False, lora_r: int = 8, lora_alpha: int = 16,
-               lora_dropout: float = 0.1, lora_target_modules: list = None):
+               lora_dropout: float = 0.1, lora_target_modules: list = None,
+               holdout_path: str = None):
     super().__init__()
 
     self.mask = np.concatenate([SURVEY_MASK[:, :88], SURVEY_MASK[620:1030, 88:]])
@@ -146,7 +148,8 @@ class RegressionModelNoPatch(L.LightningModule):
       'lora_r': lora_r,
       'lora_alpha': lora_alpha,
       'lora_dropout': lora_dropout,
-      'lora_target_modules': lora_target_modules_used  # Save the actual modules used, not None
+      'lora_target_modules': lora_target_modules_used,  # Save the actual modules used, not None
+      'holdout_path': holdout_path,
     })
 
     self.reshape_head = nn.Sequential(
@@ -433,3 +436,56 @@ class RegressionModelNoPatch(L.LightningModule):
             "frequency": 1,
         },
     }
+
+  def evaluate_on_holdout(self, holdout_path: str = None, batch_size: int = 64, max_samples: int = None):
+    """Evaluate score/MSE on the held-out test dataset (genuine generalization test, separate
+    from the ChallengeDataModule's internal train/validation split). Maps in this dataset are
+    already noisy and masked, so no augmentation is applied here."""
+    from datasets import load_from_disk
+
+    holdout_path = holdout_path or self.hparams.holdout_path
+    if not holdout_path:
+      return None
+
+    holdout = load_from_disk(holdout_path)["train"].with_format("numpy")
+    n = len(holdout) if max_samples is None else min(max_samples, len(holdout))
+
+    device = self.device
+    theta_mean_t = torch.tensor(THETA_MEAN[:2], device=device, dtype=torch.float32)
+    theta_std_t = torch.tensor(THETA_STD[:2], device=device, dtype=torch.float32)
+
+    was_training = self.training
+    self.eval()
+    scores, mses = [], []
+    with torch.no_grad():
+      for start in range(0, n, batch_size):
+        batch = holdout[start:start + batch_size]
+        kappa = reshape_field_numpy(np.array(batch["kappa"]))  # (B, 1834, 88)
+        theta = np.array(batch["theta"])[:, :2]  # (B, 2), physical units
+
+        x = torch.from_numpy(kappa).float().to(device)
+        mean, std, _ = self(x)
+        mean = mean * theta_std_t + theta_mean_t
+        std = std * theta_std_t
+        y = torch.from_numpy(theta).float().to(device)
+
+        sq_error = (y - mean) ** 2
+        score = -torch.sum(sq_error / std**2 + torch.log(std**2) + 1000.0 * sq_error, dim=1)
+        mse = F.mse_loss(mean, y, reduction="none").mean(dim=1)
+        scores.extend(score.cpu().tolist())
+        mses.extend(mse.cpu().tolist())
+    if was_training:
+      self.train()
+
+    return float(np.mean(scores)), float(np.mean(mses))
+
+  def on_train_end(self):
+    """Once training finishes, run a single evaluation pass on the held-out test dataset
+    and log the resulting score/MSE to wandb."""
+    result = self.evaluate_on_holdout()
+    if result is None:
+      return
+    holdout_score, holdout_mse = result
+    print(f"Holdout score: {holdout_score:.4f}, Holdout MSE: {holdout_mse:.6f}")
+    if self.logger is not None:
+      self.logger.experiment.log({"holdout_score": holdout_score, "holdout_mse": holdout_mse})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,10 @@ dependencies = [
     "omegaconf",
     "wandb",
     "peft",
-    "nflows"
+    "nflows",
+    "tarp",
+    "mira_score",
+    "getdist",
 ]
 
 [project.optional-dependencies]

--- a/scripts/plot_fom_budget.py
+++ b/scripts/plot_fom_budget.py
@@ -34,18 +34,33 @@ def _plot_core(npe_results_path: Path, output_path: str):
         print(f"  budget={r['budget']:>6d}: FoM = {r['fom_mean']:.2f} ± {r['fom_std']:.2f} "
               f"(val_nll={r['best_val_nll']:.4f})")
 
+    def _mira(r):
+        """Prefer the flat_val MIRA score (proper held-out test); fall back to npe_val."""
+        calib = r.get("calibration", {})
+        for tag in ("flat_val", "npe_val"):
+            if tag in calib:
+                return calib[tag]["mira_mean"], calib[tag]["mira_std"]
+        return np.nan, np.nan
+
     budgets = np.array([r["budget"] for r in all_results])
     fom_means = np.array([r["fom_mean"] for r in all_results])
     fom_stds = np.array([r["fom_std"] for r in all_results])
-    val_nlls = np.array([r["best_val_nll"] for r in all_results])                                                                                                                                                
-    mse_means = np.array([r["mse_mean"] for r in all_results])                                                                                                                                                   
-    mse_stds = np.array([r["mse_std"] for r in all_results]) 
+    val_nlls = np.array([r["best_val_nll"] for r in all_results])
+    mse_means = np.array([r.get("mse_mean", np.nan) for r in all_results])
+    mse_stds = np.array([r.get("mse_std", np.nan) for r in all_results])
+    score_means = np.array([r.get("score_mean", np.nan) for r in all_results])
+    score_stds = np.array([r.get("score_std", np.nan) for r in all_results])
+    mira_pairs = [_mira(r) for r in all_results]
+    mira_means = np.array([m for m, _ in mira_pairs])
+    mira_stds = np.array([s for _, s in mira_pairs])
 
     order = np.argsort(budgets)
-    budgets = budgets[order]                                                                                                                                                                                     
-    fom_means, fom_stds = fom_means[order], fom_stds[order]                                                                                                                                                      
-    val_nlls = val_nlls[order]                                                                                                                                                                                   
-    mse_means, mse_stds = mse_means[order], mse_stds[order] 
+    budgets = budgets[order]
+    fom_means, fom_stds = fom_means[order], fom_stds[order]
+    val_nlls = val_nlls[order]
+    mse_means, mse_stds = mse_means[order], mse_stds[order]
+    score_means, score_stds = score_means[order], score_stds[order]
+    mira_means, mira_stds = mira_means[order], mira_stds[order]
 
     fig, ax = plt.subplots(figsize=(8, 5))
     ax.errorbar(budgets, fom_means, yerr=fom_stds,
@@ -59,51 +74,74 @@ def _plot_core(npe_results_path: Path, output_path: str):
     fig.tight_layout()
     fig.savefig(output_path, dpi=150)
 
-    fig, axes = plt.subplots(1, 3, figsize=(18, 5))                                                                                                                                                                                                                                                                                                                                                                
-    axes[0].errorbar(budgets, fom_means, yerr=fom_stds,                                                                                                                                                          
-                        fmt="o-", color="C0", markersize=8, capsize=4, linewidth=1.5)                                                                                                                               
-    axes[0].set_xscale("log")                                                                                                                                                                                    
-    axes[0].set_xlabel("Simulation budget", fontsize=13)                                                                                                                                                         
-    axes[0].set_ylabel("Figure of Merit (FoM)", fontsize=13)                                                                                                                                                     
-    axes[0].set_title("FoM vs budget", fontsize=14)                                                                                                                                                              
-    axes[0].grid(True, alpha=0.3)                                                                                                                                                                                
-                                                                                                                                                                                                            
-    axes[1].plot(budgets, val_nlls, "o-", color="C1", markersize=8, linewidth=1.5)                                                                                                                               
-    axes[1].set_xscale("log")                                                                                                                                                                                    
-    axes[1].set_xlabel("Simulation budget", fontsize=13)                                                                                                                                                         
-    axes[1].set_ylabel("Best val NLL", fontsize=13)                                                                                                                                                              
-    axes[1].set_title("NPE val NLL vs budget", fontsize=14)                                                                                                                                                      
-    axes[1].grid(True, alpha=0.3)                                                                                                                                                                                
-                                                                                                                                                                                                            
-    axes[2].errorbar(budgets, mse_means, yerr=mse_stds,                                                                                                                                                          
-                        fmt="o-", color="C2", markersize=8, capsize=4, linewidth=1.5)                                                                                                                               
-    axes[2].set_xscale("log")                                                                                                                                                                                    
-    axes[2].set_xlabel("Simulation budget", fontsize=13)                                                                                                                                                         
-    axes[2].set_ylabel("MSE", fontsize=13)                                                                                                                                                                       
-    axes[2].set_title("Posterior MSE vs budget", fontsize=14)                                                                                                                                                    
-    axes[2].grid(True, alpha=0.3)                                                                                                                                                                                
-                                                                                                                                                                                                            
-    for ax in axes:                                                                                                                                                                                              
-        ax.tick_params(labelsize=11)  
+    fig, axes = plt.subplots(2, 3, figsize=(18, 10))
+    axes = axes.flatten()
+    axes[0].errorbar(budgets, fom_means, yerr=fom_stds,
+                        fmt="o-", color="C0", markersize=8, capsize=4, linewidth=1.5)
+    axes[0].set_xscale("log")
+    axes[0].set_xlabel("Simulation budget", fontsize=13)
+    axes[0].set_ylabel("Figure of Merit (FoM)", fontsize=13)
+    axes[0].set_title("FoM vs budget", fontsize=14)
+    axes[0].grid(True, alpha=0.3)
+
+    axes[1].plot(budgets, val_nlls, "o-", color="C1", markersize=8, linewidth=1.5)
+    axes[1].set_xscale("log")
+    axes[1].set_xlabel("Simulation budget", fontsize=13)
+    axes[1].set_ylabel("Best val NLL", fontsize=13)
+    axes[1].set_title("NPE val NLL vs budget", fontsize=14)
+    axes[1].grid(True, alpha=0.3)
+
+    axes[2].errorbar(budgets, mse_means, yerr=mse_stds,
+                        fmt="o-", color="C2", markersize=8, capsize=4, linewidth=1.5)
+    axes[2].set_xscale("log")
+    axes[2].set_xlabel("Simulation budget", fontsize=13)
+    axes[2].set_ylabel("MSE", fontsize=13)
+    axes[2].set_title("Compressor MSE vs budget", fontsize=14)
+    axes[2].grid(True, alpha=0.3)
+
+    axes[3].errorbar(budgets, score_means, yerr=score_stds,
+                        fmt="o-", color="C3", markersize=8, capsize=4, linewidth=1.5)
+    axes[3].set_xscale("log")
+    axes[3].set_xlabel("Simulation budget", fontsize=13)
+    axes[3].set_ylabel("Score", fontsize=13)
+    axes[3].set_title("Compressor score vs budget", fontsize=14)
+    axes[3].grid(True, alpha=0.3)
+
+    axes[4].errorbar(budgets, mira_means, yerr=mira_stds,
+                        fmt="o-", color="C4", markersize=8, capsize=4, linewidth=1.5)
+    axes[4].set_xscale("log")
+    axes[4].set_xlabel("Simulation budget", fontsize=13)
+    axes[4].set_ylabel("MIRA score", fontsize=13)
+    axes[4].set_title("MIRA calibration vs budget", fontsize=14)
+    axes[4].grid(True, alpha=0.3)
+
+    axes[5].axis("off")
+
+    for ax in axes:
+        ax.tick_params(labelsize=11)
 
     fig.tight_layout()
     fig.savefig(output_path.replace(".pdf", "_full.pdf"), dpi=150)
-    print(f"Plot saved to {output_path} and {output_path.replace('.pdf', '_full.pdf')}")      
+    print(f"Plot saved to {output_path} and {output_path.replace('.pdf', '_full.pdf')}")
 
 
-    # Saving data points for the plots above. 
-    if ".pdf" in output_path: 
+    # Saving data points for the plots above.
+    if ".pdf" in output_path:
         output_path = output_path.split(".pdf")[0]
-    
+
     np.savez(
         output_path + ".npz",
-        budgets = budgets, 
-        fom_means = fom_means, 
-        fom_stds = fom_stds, 
-        mse_means = mse_means, 
-        mse_stds = mse_stds, 
+        budgets = budgets,
+        fom_means = fom_means,
+        fom_stds = fom_stds,
+        mse_means = mse_means,
+        mse_stds = mse_stds,
+        score_means = score_means,
+        score_stds = score_stds,
+        mira_means = mira_means,
+        mira_stds = mira_stds,
         val_nlls = val_nlls
-    )                                                                                                                                                                
+    )
                                 
 
 

--- a/scripts/run_npe_budget_scan.py
+++ b/scripts/run_npe_budget_scan.py
@@ -36,6 +36,9 @@ class NPEConfig:
     npe_patience: int = 50
     npe_seeds: int = 5
     n_posterior_samples: int = 10_000
+    # Calibration validation (TARP + MIRA) on the flat dataset validation split
+    n_val_maps: int = 500
+    n_val_posterior_samples: int = 1000
 
     @classmethod
     def from_yaml(cls, path: str) -> "NPEConfig":
@@ -115,7 +118,7 @@ def find_best_checkpoint(budget: int, checkpoints_path: Path, offline: bool = Fa
     raise FileNotFoundError(f"No checkpoint found for budget-{budget}")
 
 
-def _train_budget_core(budget: int, checkpoints_path, npe_results_path, summaries_cache_path, load_holdout, cfg: NPEConfig, offline: bool = False, vol=None):
+def _train_budget_core(budget: int, checkpoints_path, npe_results_path, summaries_cache_path, load_holdout, cfg: NPEConfig, offline: bool = False, vol=None, load_flat_val=None):
     """Core NPE pipeline, independent of Modal or local execution.
 
     Args:
@@ -479,6 +482,103 @@ def _train_budget_core(budget: int, checkpoints_path, npe_results_path, summarie
         "best_val_nll": best_val_nll,
         "best_seed/posterior_plot": wandb.Image(str(plot_path)),
     })
+
+    # ── 9. TARP + MIRA calibration tests ──
+    # 9a: on the NPE's own held-out validation data (same distribution as training — sanity check)
+    # 9b: on the flat dataset validation split (held-out maps, needs noise+mask)
+    try:
+        from tarp import get_tarp_coverage
+        from mira_score import mira as mira_score
+        import torch as _torch
+
+        def _run_calibration(summaries_t, theta_norm, tag, n_cap=None):
+            """Sample posteriors then run TARP + MIRA. Returns (ecp, alpha, mira_mean, mira_std)."""
+            n = len(summaries_t) if n_cap is None else min(n_cap, len(summaries_t))
+            summaries_t = summaries_t[:n]
+            theta_norm = theta_norm[:n]
+
+            posterior = []
+            with _torch.no_grad():
+                for i in range(n):
+                    s_i = summaries_t[i:i+1].to(device)
+                    samps = flow.sample(cfg.n_val_posterior_samples, context=s_i)  # (1, S, 2)
+                    posterior.append(samps.squeeze(0).cpu().numpy())
+            posterior_arr = np.stack(posterior, axis=0)  # (n, S, 2)
+
+            ecp, alpha = get_tarp_coverage(
+                samples=posterior_arr.transpose(1, 0, 2),  # (S, n, 2)
+                theta=theta_norm,
+                references="random",
+                metric="euclidean",
+                norm=True,
+            )
+            posterior_torch = _torch.from_numpy(posterior_arr).unsqueeze(0)  # (1, n, S, 2)
+            truth_torch = _torch.from_numpy(theta_norm.astype(np.float32))
+            m_mean, m_std = mira_score(truth_torch, posterior_torch, num_runs=100, device=device)
+
+            # TARP plot
+            fig, ax = plt.subplots(figsize=(5, 5))
+            ax.plot(alpha, ecp, lw=2, label="NPE")
+            ax.plot([0, 1], [0, 1], "k--", lw=1, label="Ideal")
+            ax.fill_between(alpha, alpha, ecp, alpha=0.15)
+            ax.set_xlabel("Credibility level α")
+            ax.set_ylabel("Expected coverage probability")
+            ax.set_title(f"TARP [{tag}] budget={budget}, n={n}")
+            ax.legend()
+            tarp_path = results_dir / f"tarp_coverage_{tag}.png"
+            fig.savefig(str(tarp_path), dpi=150, bbox_inches="tight")
+            plt.close(fig)
+
+            print(f"  [{tag}] TARP max|ecp-α| = {np.max(np.abs(ecp - alpha)):.4f}  "
+                  f"MIRA = {float(m_mean[0]):.4f} ± {float(m_std[0]):.4f}")
+            wandb.log({
+                f"calibration/{tag}/tarp_plot": wandb.Image(str(tarp_path)),
+                f"calibration/{tag}/mira_score": float(m_mean[0]),
+                f"calibration/{tag}/mira_std": float(m_std[0]),
+                f"calibration/{tag}/tarp_max_deviation": float(np.max(np.abs(ecp - alpha))),
+                f"calibration/{tag}/n_maps": n,
+            })
+            np.save(results_dir / f"tarp_ecp_{tag}.npy", ecp)
+            np.save(results_dir / f"tarp_alpha_{tag}.npy", alpha)
+            np.save(results_dir / f"val_posterior_samples_{tag}.npy", posterior_arr)
+            return ecp, alpha, m_mean, m_std
+
+        # 9a — NPE validation split (already computed, no reprocessing needed)
+        print("\nCalibration 9a: NPE held-out validation data...")
+        _run_calibration(
+            s_val.cpu(),
+            t_val.cpu().numpy(),
+            tag="npe_val",
+            n_cap=cfg.n_val_maps,
+        )
+
+        # 9b — flat dataset validation split (raw maps: add noise + mask first)
+        if load_flat_val is not None:
+            print("\nCalibration 9b: flat dataset validation split...")
+            from cosmoford import NOISE_STD as _NOISE_STD
+            _mask = np.concatenate([SURVEY_MASK[:, :88], SURVEY_MASK[620:1030, 88:]])
+            rng_val = np.random.default_rng(99)
+
+            flat_val = load_flat_val("validation").with_format("numpy")
+            n_flat = min(cfg.n_val_maps, len(flat_val))
+            kappa_flat = np.array(flat_val[:n_flat]["kappa"])
+            theta_flat = np.array(flat_val[:n_flat]["theta"])
+            theta_flat_norm = ((theta_flat[:, :2] - THETA_MEAN[:2]) / THETA_STD[:2]).astype(np.float32)
+
+            flat_summaries = []
+            with _torch.no_grad():
+                for kappa_i in kappa_flat:
+                    kappa_rs = reshape_field_numpy(kappa_i[np.newaxis])[0]
+                    kappa_noisy = (kappa_rs + rng_val.standard_normal(kappa_rs.shape) * _NOISE_STD) * _mask
+                    x = _torch.from_numpy(kappa_noisy.astype(np.float32)).unsqueeze(0).to(device)
+                    flat_summaries.append(compressor.compress(x).cpu())
+            flat_summaries_t = _torch.cat(flat_summaries, dim=0)
+
+            _run_calibration(flat_summaries_t, theta_flat_norm, tag="flat_val")
+
+    except Exception as e:
+        print(f"WARNING: TARP/MIRA calibration failed: {e}")
+
     wandb.finish()
 
     if vol is not None:
@@ -510,6 +610,9 @@ if __name__ != "__main__":
             "nflows",
             "matplotlib",
             "scikit-learn",
+            "tarp",
+            "mira_score",
+            "getdist",
         )
         .add_local_dir("cosmoford", "/root/cosmoford", copy=True)
         .add_local_dir("configs", "/root/configs", copy=True)
@@ -545,6 +648,7 @@ if __name__ != "__main__":
             lambda split: _hf_load("CosmoStat/neurips-wl-challenge-holdout", split=split),
             cfg,
             vol=volume,
+            load_flat_val=lambda split: _hf_load("CosmoStat/neurips-wl-challenge-flat", split=split),
         )
 
     @app.function(
@@ -596,6 +700,9 @@ if __name__ == "__main__":
                         help="Path for caching pre-computed summaries")
     parser.add_argument("--holdout_path", required=True,
                         help="Path to holdout DatasetDict (save_to_disk format, 'train' and 'fiducial' splits)")
+    parser.add_argument("--flat_dataset_path", default=None,
+                        help="Path to neurips-wl-challenge-flat DatasetDict (save_to_disk format). "
+                             "If provided, TARP and MIRA calibration tests are run on the 'validation' split.")
     parser.add_argument("--config", required=True,
                         help="Path to YAML config file (configs/experiments/npe_budget_scan.yaml)")
     parser.add_argument("--budgets",
@@ -610,6 +717,7 @@ if __name__ == "__main__":
         cfg.budgets = [int(b) for b in args.budgets.split(",")]
 
     holdout_ds = load_from_disk(args.holdout_path)
+    flat_ds = load_from_disk(args.flat_dataset_path) if args.flat_dataset_path else None
 
     for budget in cfg.budgets:
         _train_budget_core(
@@ -620,4 +728,5 @@ if __name__ == "__main__":
             lambda split, ds=holdout_ds: ds[split],
             cfg,
             offline=args.offline,
+            load_flat_val=(lambda split, ds=flat_ds: ds[split]) if flat_ds is not None else None,
         )

--- a/scripts/run_npe_budget_scan.py
+++ b/scripts/run_npe_budget_scan.py
@@ -135,6 +135,7 @@ def _train_budget_core(budget: int, checkpoints_path, npe_results_path, summarie
 
     import numpy as np
     import torch
+    import torch.nn.functional as F
 
     from cosmoford import NOISE_STD, THETA_MEAN, THETA_STD
     from cosmoford.dataset import reshape_field_numpy
@@ -368,19 +369,25 @@ def _train_budget_core(budget: int, checkpoints_path, npe_results_path, summarie
     holdout = load_holdout("fiducial")
     holdout = holdout.with_format("numpy")
     kappa_all_fom = np.array(holdout["kappa"])
+    theta_all_fom = np.array(holdout["theta"])
     print(f"  Using {len(kappa_all_fom)} fiducial maps")
 
     from cosmoford import SURVEY_MASK
     mask = np.concatenate([SURVEY_MASK[:, :88], SURVEY_MASK[620:1030, 88:]])
 
+    theta_mean_t = torch.tensor(THETA_MEAN[:2], device=device, dtype=torch.float32)
+    theta_std_t = torch.tensor(THETA_STD[:2], device=device, dtype=torch.float32)
+
     fom_values = []
+    mse_values = []  # compressor regression-head MSE, same formula as RegressionModelNoPatch.validation_step
+    score_values = []  # compressor regression-head score, same formula as RegressionModelNoPatch.validation_step
     all_posterior_samples = []  # (n_maps, n_posterior_samples, 2) in physical units
     with torch.no_grad():
-        for kappa_i in kappa_all_fom:
+        for i, kappa_i in enumerate(kappa_all_fom):
             kappa_reshaped = reshape_field_numpy(kappa_i[np.newaxis])[0]
             noisy = kappa_reshaped
             x = torch.from_numpy(noisy).unsqueeze(0).to(device)
-            s = compressor.compress(x)  # (1, 8)
+            mean_raw, std_raw, s = compressor(x)  # mean/std in normalized parameter space, s: (1, 8)
 
             # Sample posterior
             samples = flow.sample(cfg.n_posterior_samples, context=s)  # (1, N, 2)
@@ -399,9 +406,26 @@ def _train_budget_core(budget: int, checkpoints_path, npe_results_path, summarie
                 fom = 0.0
             fom_values.append(fom)
 
+            # Compressor regression-head mse/score against the true fiducial theta
+            y_phys = torch.tensor(theta_all_fom[i, :2], device=device, dtype=torch.float32).unsqueeze(0)
+            mean_phys = mean_raw * theta_std_t + theta_mean_t
+            std_phys = std_raw * theta_std_t
+            sq_error = (y_phys - mean_phys) ** 2
+            score_i = -torch.sum(sq_error / std_phys**2 + torch.log(std_phys**2) + 1000.0 * sq_error, dim=1)
+            mse_i = F.mse_loss(mean_phys, y_phys)
+            score_values.append(score_i.item())
+            mse_values.append(mse_i.item())
+
     fom_mean = np.mean(fom_values)
     fom_std = np.std(fom_values)
     print(f"  FoM = {fom_mean:.2f} ± {fom_std:.2f}")
+
+    mse_mean = np.mean(mse_values)
+    mse_std = np.std(mse_values)
+    score_mean = np.mean(score_values)
+    score_std = np.std(score_values)
+    print(f"  MSE = {mse_mean:.6f} ± {mse_std:.6f}")
+    print(f"  Score = {score_mean:.2f} ± {score_std:.2f}")
 
     # ── 7. Save results ──
     torch.save(best_state, results_dir / "npe_flow.pt")
@@ -418,6 +442,12 @@ def _train_budget_core(budget: int, checkpoints_path, npe_results_path, summarie
         "fom_mean": float(fom_mean),
         "fom_std": float(fom_std),
         "fom_values": [float(v) for v in fom_values],
+        "mse_mean": float(mse_mean),
+        "mse_std": float(mse_std),
+        "mse_values": [float(v) for v in mse_values],
+        "score_mean": float(score_mean),
+        "score_std": float(score_std),
+        "score_values": [float(v) for v in score_values],
         "best_val_nll": float(best_val_nll),
         "n_noise_realizations": cfg.n_noise_realizations,
         "n_fiducial_maps": len(kappa_all_fom),
@@ -479,6 +509,10 @@ def _train_budget_core(budget: int, checkpoints_path, npe_results_path, summarie
     wandb.log({
         "fom_mean": fom_mean,
         "fom_std": fom_std,
+        "mse_mean": mse_mean,
+        "mse_std": mse_std,
+        "score_mean": score_mean,
+        "score_std": score_std,
         "best_val_nll": best_val_nll,
         "best_seed/posterior_plot": wandb.Image(str(plot_path)),
     })
@@ -486,6 +520,7 @@ def _train_budget_core(budget: int, checkpoints_path, npe_results_path, summarie
     # ── 9. TARP + MIRA calibration tests ──
     # 9a: on the NPE's own held-out validation data (same distribution as training — sanity check)
     # 9b: on the flat dataset validation split (held-out maps, needs noise+mask)
+    calibration_results = {}
     try:
         from tarp import get_tarp_coverage
         from mira_score import mira as mira_score
@@ -545,12 +580,17 @@ def _train_budget_core(budget: int, checkpoints_path, npe_results_path, summarie
 
         # 9a — NPE validation split (already computed, no reprocessing needed)
         print("\nCalibration 9a: NPE held-out validation data...")
-        _run_calibration(
+        ecp_a, alpha_a, mira_mean_a, mira_std_a = _run_calibration(
             s_val.cpu(),
             t_val.cpu().numpy(),
             tag="npe_val",
             n_cap=cfg.n_val_maps,
         )
+        calibration_results["npe_val"] = {
+            "mira_mean": float(mira_mean_a[0]),
+            "mira_std": float(mira_std_a[0]),
+            "tarp_max_deviation": float(np.max(np.abs(ecp_a - alpha_a))),
+        }
 
         # 9b — flat dataset validation split (raw maps: add noise + mask first)
         if load_flat_val is not None:
@@ -574,10 +614,21 @@ def _train_budget_core(budget: int, checkpoints_path, npe_results_path, summarie
                     flat_summaries.append(compressor.compress(x).cpu())
             flat_summaries_t = _torch.cat(flat_summaries, dim=0)
 
-            _run_calibration(flat_summaries_t, theta_flat_norm, tag="flat_val")
+            ecp_b, alpha_b, mira_mean_b, mira_std_b = _run_calibration(
+                flat_summaries_t, theta_flat_norm, tag="flat_val"
+            )
+            calibration_results["flat_val"] = {
+                "mira_mean": float(mira_mean_b[0]),
+                "mira_std": float(mira_std_b[0]),
+                "tarp_max_deviation": float(np.max(np.abs(ecp_b - alpha_b))),
+            }
 
     except Exception as e:
         print(f"WARNING: TARP/MIRA calibration failed: {e}")
+
+    if calibration_results:
+        results["calibration"] = calibration_results
+        (results_dir / "results.json").write_text(json.dumps(results, indent=2))
 
     wandb.finish()
 


### PR DESCRIPTION
After training the NPE flow, we now run two calibration checks:
- on the NPE's own held-out validation split (sanity check)
- on the validation split of CosmoStat/neurips-wl-challenge-flat 

Results (TARP coverage curve, MIRA score, posterior samples) are saved to `npe_results/budget-<N>/ ` and logged to W&B. 